### PR TITLE
Updates to tangerine-proxy OpenShift configs

### DIFF
--- a/openshift/proxy/Dockerfile
+++ b/openshift/proxy/Dockerfile
@@ -1,7 +1,9 @@
-  FROM quay.io/cloudservices/caddy-ubi:latest
+FROM quay.io/cloudservices/caddy-ubi:latest
 
-  ENV CADDY_TLS_MODE http_port 8000
+ENV CADDY_TLS_MODE="http_port 8000"
 
-  COPY ./Caddyfile /opt/app-root/src/Caddyfile
+COPY ./Caddyfile /opt/app-root/src/Caddyfile
 
-  CMD ["caddy", "run", "--config", "/opt/app-root/src/Caddyfile"]
+WORKDIR /opt/app-root/src
+
+CMD ["caddy", "run", "--config", "/opt/app-root/src/Caddyfile"]

--- a/openshift/proxy/template.yaml
+++ b/openshift/proxy/template.yaml
@@ -25,6 +25,9 @@ parameters:
 - name: HOSTNAME
   description: The hostname of the Route/Ingress
   required: true
+- name: NAMESPACE
+  description: Namespace that the proxy runs in
+  value: tangerine
 
 objects:
 - apiVersion: v1
@@ -33,6 +36,20 @@ objects:
     name: tangerine-proxy
     annotations:
        serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"tangerine-proxy"}}'
+
+# NOTE: cluster admin rights needed to apply this ClusterRoleBinding
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
+    name: tangerine-proxy-auth-delegator
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:auth-delegator
+  subjects:
+  - kind: ServiceAccount
+    name: tangerine-proxy
+    namespace: ${NAMESPACE}
 
 - apiVersion: apps/v1
   kind: Deployment
@@ -85,6 +102,7 @@ objects:
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             - --skip-auth-regex=^/metrics
             - --pass-user-headers=true
+            - --openshift-delegate-urls={"/":{"resource":"services","name":"tangerine-proxy","verb":"get","namespace":"${NAMESPACE}"}}
           image: quay.io/openshift/origin-oauth-proxy:4.14
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
* Updates Dockerfile
* Sets up oauth-proxy sidecar to support bearer token auth so that the API can be contacted directly by external services. A user/service account must have permission to list services in `$NAMESPACE` in order for their token to work.