### PR TITLE
Adjust prompt and chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ To run the UI in a development environment, see [tangerine-frontend](https://git
 
 
 ### Available API Paths
-| Path                               | Method   | Description              |
-| ---------------------------------- | -------- | ------------------------ |
-| `/api/agents`                      | `GET`    | Get a list of all agents |
-| `/api/agents`                      | `POST`   | Create a new agent       |
-| `/api/agents/<id>`                 | `GET`    | Get an agent             |
-| `/api/agents/<id>`                 | `PUT`    | Update an agent          |
-| `/api/agents/<id>`                 | `DELETE` | Delete an agent          |
-| `/api/agents/<id>/document_upload` | `POST`   | Agent document uploads   |
-| `/api/agents/<id>/chat`            | `POST`   | Chat with an agent       |
-| `/ping`                            | `GET`    | Health check             |
+| Path                               | Method   | Description                |
+| ---------------------------------- | -------- | -------------------------- |
+| `/api/agents`                      | `GET`    | Get a list of all agents   |
+| `/api/agents`                      | `POST`   | Create a new agent         |
+| `/api/agents/<id>`                 | `GET`    | Get an agent               |
+| `/api/agents/<id>`                 | `PUT`    | Update an agent            |
+| `/api/agents/<id>`                 | `DELETE` | Delete an agent            |
+| `/api/agents/<id>/document_upload` | `POST`   | Agent document uploads     |
+| `/api/agents/<id>/chat`            | `POST`   | Chat with an agent         |
+| `/api/agentDefaults`               | `GET`    | Get agent default settings |
+| `/ping`                            | `GET`    | Health check               |

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -17,3 +17,11 @@ LLM_TEMPERATURE = float(os.getenv("LLM_TEMPERATURE", 0.7))
 EMBED_BASE_URL = os.getenv("EMBED_BASE_URL", "http://localhost:11434/v1")
 EMBED_API_KEY = os.getenv("EMBED_API_KEY", "EMPTY")
 EMBED_MODEL_NAME = os.getenv("EMBED_MODEL_NAME", "nomic-embed-text")
+
+# for nomic: 'search_query'
+# for snowflake-arctic: 'Represent this sentence for searching relevant passages'
+EMBED_QUERY_PREFIX = os.getenv("EMBED_QUERY_PREFIX", "search_query")
+
+# for nomic: 'search_document'
+# for snowflake-arctic: ''
+EMBED_DOCUMENT_PREFIX = os.getenv("EMBED_DOCUMENT_PREFIX", "")

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -19,9 +19,9 @@ EMBED_API_KEY = os.getenv("EMBED_API_KEY", "EMPTY")
 EMBED_MODEL_NAME = os.getenv("EMBED_MODEL_NAME", "nomic-embed-text")
 
 # for nomic: 'search_query'
-# for snowflake-arctic: 'Represent this sentence for searching relevant passages'
+# for snowflake-arctic-embed-m-long: 'Represent this sentence for searching relevant passages'
 EMBED_QUERY_PREFIX = os.getenv("EMBED_QUERY_PREFIX", "search_query")
 
 # for nomic: 'search_document'
-# for snowflake-arctic: ''
+# for snowflake-arctic-embed-m-long: ''
 EMBED_DOCUMENT_PREFIX = os.getenv("EMBED_DOCUMENT_PREFIX", "")

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -25,12 +25,10 @@ DEFAULT_SYSTEM_PROMPT = """
 <s>[INST] You are a helpful assistant for software developers who answers questions based on
 information found in technical documents. You will be provided with a question and 6 search
 results that may be useful information in answering the question. Each search result is
-in markdown format. The search results are not ordered according to relevance. First,
-select which search results appear to be most relevant for answering the user's question. Next,
-provide a concise answer to the question by summarizing the relevant search results. You must
-answer the question based solely on content found in the search results. Answers must also
-consider chat history. If you are not able to answer a question, you should say "I do not have
-enough information available to be able to answer your question. [/INST]</s>
+in markdown format. The search results are not ordered according to relevance. Answer the
+question as concisely as possible by using the content of the search results. If you are not
+able to answer a question, you should say "I do not have enough information available to be
+able to answer your question. Answers must consider chat history. [/INST]</s>
 """.lstrip(
     "\n"
 ).replace(

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -59,7 +59,7 @@ class LLMInterface:
     def ask(self, system_prompt, previous_messages, question, agent_id, stream):
         results = vector_interface.search(question, agent_id)
         # sort by score, highest score first
-        results = sorted(results, key=itemgetter(2), reverse=True)
+        results = sorted(results, key=itemgetter(1), reverse=True)
         # drop the score
         results = [result[0] for result in results]
 

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -24,16 +24,23 @@ Answer the above question using the below search results as context:
 )
 
 DEFAULT_SYSTEM_PROMPT = """
-<s>[INST]You are a helpful assistant for software developers who answers questions based on
-information found in technical documents. You will be provided with a question and 3 search
-results that appear to be most relevant for answering the question. Each search result is
-in markdown format. The search results are ordered with most relevant results listed first
-and least relevant results listed last. Answer the question as concisely as possible by using
-the content of the search results. If you are not able to answer a question, you should say
-"I do not have enough information available to be able to answer your question." Answers must
-consider chat history. Always assist with care, respect, and truth. Respond with utmost utility
-yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote
-fairness and positivity.[/INST]</s>
+ <s>[INST] You are a helpful assistant helps software developers quickly find answers
+to their questions. You answer their questions as concisely as possible and point them to
+technical documents where they can find more details. You will be provided with a question
+and 4 search results that appear to be most relevant for answering the question. The start
+of the search result is indicated with text like this: <<Search result 1>>. If the title of
+the document is known, then the start of the search result will look like this:
+<<Search result 1, Document title: An Example Title>>. The end of each search result is indicated
+with text like this: <<Search result 1 END>>. The content of the search result is in markdown
+format. The search results are ordered with most relevant results listed first and least relevant
+results listed last. Answer the question as concisely as possible by using the content of the
+search results. Try to use the most relevant search results when answering the question. If the
+first search result clearly answers the question, then just use that search result and discard
+the others. If you are not able to answer a question, you should say "I do not have enough
+information available to be able to answer your question." Answers must consider chat history.
+Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid
+harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and
+positivity. [/INST]
 """.lstrip(
     "\n"
 ).replace(
@@ -62,11 +69,11 @@ class LLMInterface:
                 metadata = doc.metadata
                 extra_doc_info.append({"metadata": metadata, "page_content": page_content})
                 log.debug("metadata: %s", metadata)
-                context_text += (
-                    f"\n<<Search result {i+1}>>\n"
-                    f"{page_content}\n\n"
-                    f"<<Search result {i+1} END>>\n"
-                )
+                context_text += f"\n<<Search result {i+1}"
+                if "title" in metadata:
+                    title = metadata["title"]
+                    context_text += f", document title: '{title}'"
+                context_text += ">>\n\n" f"{page_content}\n\n" f"<<Search result {i+1} END>>\n"
             prompt = ChatPromptTemplate.from_template(USER_PROMPT_TEMPLATE)
             prompt_params = {"context": context_text, "question": question}
             log.debug("search result: %s", context_text)
@@ -77,9 +84,9 @@ class LLMInterface:
         if previous_messages:
             for msg in previous_messages:
                 if msg["sender"] == "human":
-                    msg_list.append(HumanMessage(content=msg["text"]))
+                    msg_list.append(HumanMessage(content=f"[INST] {msg['text']} [/INST]"))
                 if msg["sender"] == "ai":
-                    msg_list.append(AIMessage(content=msg["text"]))
+                    msg_list.append(AIMessage(content=f"{msg['text']}</s>"))
         prompt.messages = msg_list + prompt.messages
 
         log.debug("prompt: %s", prompt)

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -24,23 +24,23 @@ Answer the above question using the below search results as context:
 )
 
 DEFAULT_SYSTEM_PROMPT = """
- <s>[INST] You are a helpful assistant helps software developers quickly find answers
-to their questions. You answer their questions as concisely as possible and point them to
-technical documents where they can find more details. You will be provided with a question
-and 4 search results that appear to be most relevant for answering the question. The start
-of the search result is indicated with text like this: <<Search result 1>>. If the title of
-the document is known, then the start of the search result will look like this:
-<<Search result 1, Document title: An Example Title>>. The end of each search result is indicated
-with text like this: <<Search result 1 END>>. The content of the search result is in markdown
-format. The search results are ordered with most relevant results listed first and least relevant
-results listed last. Answer the question as concisely as possible by using the content of the
-search results. Try to use the most relevant search results when answering the question. If the
-first search result clearly answers the question, then just use that search result and discard
-the others. If you are not able to answer a question, you should say "I do not have enough
-information available to be able to answer your question." Answers must consider chat history.
-Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid
-harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and
-positivity. [/INST]
+ <s>[INST] You are an assistant who helps software developers quickly find answers to their
+questions by reviewing technical documents. You answer their questions as concisely as possible and
+point them to the technical documents where they can find more details. You will be provided with a
+question and search results that appear to be most relevant for answering the question. The start
+marker for each search result is similar to this: <<Search result 1>>. If the title of the document
+is known, then the start marker result is similar to this: <<Search result 1, Document title: An
+Example Title>>. The end marker of each search result is similar to this: <<Search result 1 END>>.
+The content of the search result is found between the start marker and the end marker and is a
+snippet of technical documentation in markdown format. The search results are ordered with the most
+relevant results listed first and least relevant results listed last. Answer the question as
+concisely as possible by using the content of the search results. Try to use the most relevant
+search results when answering the question. If the first search result clearly answers the
+question, then just use that search result and discard the others. If you are not able to answer a
+question, you should say "I do not have enough information available to be able to answer your
+question." Answers must consider chat history. Always assist with care, respect, and truth. Respond
+with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure
+replies promote fairness and positivity. [/INST]
 """.lstrip(
     "\n"
 ).replace(

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -12,7 +12,7 @@ from connectors.vector_store.db import vector_interface
 USER_PROMPT_TEMPLATE = """
 Question: {question}
 
-Answer the question based solely on the following document chunks:
+Answer the question using the following search results as context:
 
 {context}
 """.lstrip(
@@ -23,14 +23,14 @@ Answer the question based solely on the following document chunks:
 
 DEFAULT_SYSTEM_PROMPT = """
 <s>[INST] You are a helpful assistant for software developers who answers questions based on
-information found in technical documents. You will be provided with a question and 6 document
-chunks that may provide useful information in answering the question. The document chunks are in
-markdown format. They are not ordered according to relevance. Use the document chunks as context to
-answer the user's question as concisely as possible. You should answer the question based solely on
-provided document content. Do not mention anything about "document chunks" in your response;
-instead, you should call them "the information available to me". If you do not know the answer to a
-question, you must let the user know this and you must not infer an answer. Your answers need to
-consider chat history. [/INST]</s>
+information found in technical documents. You will be provided with a question and 6 search
+results that may be useful information in answering the question. Each search result is
+in markdown format. The search results are not ordered according to relevance. First,
+select which search results appear to be most relevant for answering the user's question. Next,
+provide a concise answer to the question by summarizing the relevant search results. You must
+answer the question based solely on content found in the search results. Answers must also
+consider chat history. If you are not able to answer a question, you should say "I do not have
+enough information available to be able to answer your question. [/INST]</s>
 """.lstrip(
     "\n"
 ).replace(
@@ -60,9 +60,9 @@ class LLMInterface:
                 extra_doc_info.append({"metadata": metadata, "page_content": page_content})
                 log.debug("metadata: %s", metadata)
                 context_text += (
-                    f"\n<<Document Chunk {i+1}>>\n"
+                    f"\n<<Search result {i+1}>>\n"
                     f"{page_content}\n\n"
-                    f"<<Document Chunk {i+1} END>>\n"
+                    f"<<Search result {i+1} END>>\n"
                 )
             prompt = ChatPromptTemplate.from_template(USER_PROMPT_TEMPLATE)
             prompt_params = {"context": context_text, "question": question}

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -58,8 +58,8 @@ class LLMInterface:
 
     def ask(self, system_prompt, previous_messages, question, agent_id, stream):
         results = vector_interface.search(question, agent_id)
-        # sort by score, highest score first
-        results = sorted(results, key=itemgetter(1), reverse=True)
+        # sort by score lowest to highest, lower is "less distance" which is better
+        results = sorted(results, key=itemgetter(1))
         # drop the score
         results = [result[0] for result in results]
 

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -10,11 +10,13 @@ import connectors.config as cfg
 from connectors.vector_store.db import vector_interface
 
 USER_PROMPT_TEMPLATE = """
+[INST]
 Question: {question}
 
-Answer the question using the following search results as context:
+Answer the above question using the below search results as context:
 
 {context}
+[/INST]
 """.lstrip(
     "\n"
 ).rstrip(
@@ -22,13 +24,16 @@ Answer the question using the following search results as context:
 )
 
 DEFAULT_SYSTEM_PROMPT = """
-<s>[INST] You are a helpful assistant for software developers who answers questions based on
-information found in technical documents. You will be provided with a question and 6 search
-results that may be useful information in answering the question. Each search result is
-in markdown format. The search results are not ordered according to relevance. Answer the
-question as concisely as possible by using the content of the search results. If you are not
-able to answer a question, you should say "I do not have enough information available to be
-able to answer your question. Answers must consider chat history. [/INST]</s>
+<s>[INST]You are a helpful assistant for software developers who answers questions based on
+information found in technical documents. You will be provided with a question and 3 search
+results that appear to be most relevant for answering the question. Each search result is
+in markdown format. The search results are ordered with most relevant results listed first
+and least relevant results listed last. Answer the question as concisely as possible by using
+the content of the search results. If you are not able to answer a question, you should say
+"I do not have enough information available to be able to answer your question." Answers must
+consider chat history. Always assist with care, respect, and truth. Respond with utmost utility
+yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote
+fairness and positivity.[/INST]</s>
 """.lstrip(
     "\n"
 ).replace(

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from operator import itemgetter
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
@@ -40,9 +39,11 @@ for easy readability. Try to use the most relevant search results when answering
 the first search result clearly answers the question, then just use that search result and discard
 the others. If you are not able to answer a question, you should say "I do not have enough
 information available to be able to answer your question." After you answer the question, indicate
-which search result you used to formulate your answer. Answers must consider chat history.  Always
-assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid harmful,
-unethical, prejudiced, or negative content. Ensure replies promote fairness and positivity. [/INST]
+which search result you used to formulate your answer and provide the name of the document title if
+it exists. Do not generate example URL links to the documents. Answers must consider chat history.
+Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid
+harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and
+positivity. [/INST]
 """.lstrip(
     "\n"
 ).replace(
@@ -58,10 +59,6 @@ class LLMInterface:
 
     def ask(self, system_prompt, previous_messages, question, agent_id, stream):
         results = vector_interface.search(question, agent_id)
-        # sort by score lowest to highest, lower is "less distance" which is better
-        results = sorted(results, key=itemgetter(1))
-        # drop the score
-        results = [result[0] for result in results]
 
         prompt_params = {"question": question}
         prompt = ChatPromptTemplate.from_template("{question}")

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -24,7 +24,7 @@ Answer the above question using the below search results as context:
 )
 
 DEFAULT_SYSTEM_PROMPT = """
- <s>[INST] You are an assistant who helps software developers quickly find answers to their
+<s>[INST] You are an assistant who helps software developers quickly find answers to their
 questions by reviewing technical documents. You answer their questions as concisely as possible and
 point them to the technical documents where they can find more details. You will be provided with a
 question and search results that appear to be most relevant for answering the question. The start
@@ -38,9 +38,10 @@ concisely as possible by using the content of the search results. Try to use the
 search results when answering the question. If the first search result clearly answers the
 question, then just use that search result and discard the others. If you are not able to answer a
 question, you should say "I do not have enough information available to be able to answer your
-question." Answers must consider chat history. Always assist with care, respect, and truth. Respond
-with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure
-replies promote fairness and positivity. [/INST]
+question." After you answer the question, indicate which search result number you used to formulate
+your answer. Answers must consider chat history. Always assist with care, respect, and truth.
+Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative
+content. Ensure replies promote fairness and positivity. [/INST]
 """.lstrip(
     "\n"
 ).replace(

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -39,9 +39,10 @@ search results when answering the question. If the first search result clearly a
 question, then just use that search result and discard the others. If you are not able to answer a
 question, you should say "I do not have enough information available to be able to answer your
 question." After you answer the question, indicate which search result number you used to formulate
-your answer. Answers must consider chat history. Always assist with care, respect, and truth.
-Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative
-content. Ensure replies promote fairness and positivity. [/INST]
+your answer. Answers must consider chat history. Please format your answers in markdown for easy
+readability. Always assist with care, respect, and truth. Respond with utmost utility yet securely.
+Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and
+positivity. [/INST]
 """.lstrip(
     "\n"
 ).replace(

--- a/connectors/llm/interface.py
+++ b/connectors/llm/interface.py
@@ -24,26 +24,21 @@ Answer the above question using the below search results as context:
 )
 
 DEFAULT_SYSTEM_PROMPT = """
-<s>[INST] You are an assistant who helps software developers quickly find answers to their
-questions by reviewing technical documents. You answer their questions as concisely as possible and
-point them to the technical documents where they can find more details. You will be provided with a
-question and search results that appear to be most relevant for answering the question. The start
-marker for each search result is similar to this: <<Search result 1>>. If the title of the document
-is known, then the start marker result is similar to this: <<Search result 1, Document title: An
-Example Title>>. The end marker of each search result is similar to this: <<Search result 1 END>>.
-The content of the search result is found between the start marker and the end marker and is a
-snippet of technical documentation in markdown format. The search results are ordered with the most
-relevant results listed first and least relevant results listed last. Answer the question as
-concisely as possible by using the content of the search results. Format your answers in markdown
-for easy readability. Try to use the most relevant search results when answering the question. If
-the first search result clearly answers the question, then just use that search result and discard
-the others. If you are not able to answer a question, you should say "I do not have enough
-information available to be able to answer your question." After you answer the question, indicate
-which search result you used to formulate your answer and provide the name of the document title if
-it exists. Do not generate example URL links to the documents. Answers must consider chat history.
-Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid
-harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and
-positivity. [/INST]
+<s>[INST] You are a helpful assistant that helps software developers quickly find answers to their
+questions by reviewing technical documents. You will be provided with a question and search results
+that are relevant for answering the question. The start marker for each search result is similar to
+this: <<Search result 1>>. If the title of the document is known, then the start marker result is
+similar to this: <<Search result 1, Document title: An Example Title>>. The end marker of each
+search result is similar to this: <<Search result 1 END>>. The content of the search result is
+found between the start marker and the end marker and is a snippet of technical documentation in
+markdown format. The search results are ordered according to relevance with the most relevant
+search result listed first. Answer the question using the search results as context. Answer as
+concisely as possible. If the first search result provides enough information to answer the
+question, just use that single search result as context and discard the others. Your answers must
+be based solely on the content found in the search results. Format your answers in markdown for
+easy readability. If you are not able to answer a question, you should say "I do not have enough
+information available to be able to answer your question." Answers must consider chat history.
+[/INST]
 """.lstrip(
     "\n"
 ).replace(

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -47,7 +47,7 @@ class Agents(db.Model):
 class VectorStoreInterface:
     def __init__(self):
         self.store = None
-        self.vector_chunk_size = 1800
+        self.vector_chunk_size = 2000
         self.vector_chunk_overlap = 0
 
         self.embeddings = OpenAIEmbeddings(

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -10,7 +10,7 @@ from flask_sqlalchemy import SQLAlchemy
 from langchain_core.documents import Document
 from langchain_openai import OpenAIEmbeddings
 from langchain_postgres.vectorstores import PGVector
-from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_text_splitters import Language, RecursiveCharacterTextSplitter
 
 import connectors.config as cfg
 
@@ -33,8 +33,8 @@ class Agents(db.Model):
 class VectorStoreInterface:
     def __init__(self):
         self.store = None
-        self.vector_chunk_size = 1024
-        self.vector_chunk_overlap = int(self.vector_chunk_size * 0.3)
+        self.vector_chunk_size = 2000
+        self.vector_chunk_overlap = 200
 
         self.embeddings = OpenAIEmbeddings(
             model=cfg.EMBED_MODEL_NAME,
@@ -57,8 +57,9 @@ class VectorStoreInterface:
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.vector_chunk_size,
             chunk_overlap=self.vector_chunk_overlap,
-            length_function=len,
-            is_separator_regex=False,
+            separators=RecursiveCharacterTextSplitter.get_separators_for_language(
+                Language.MARKDOWN
+            ),
         )
         return text_splitter.split_documents(documents)
 

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -74,7 +74,6 @@ class VectorStoreInterface:
         a header), we will store these small chunks on the next chunk to avoid storing a
         document with small context
         """
-        indices_to_pop = []
         for idx, chunk in enumerate(chunks):
             if len(chunk) < 200:
                 # this chunk is less than 200 chars, move it to the next chunk
@@ -84,12 +83,9 @@ class VectorStoreInterface:
                     # we've reached the end and there is no 'next chunk', just give up
                     break
                 # make note of its index and pop it later...
-                indices_to_pop.append(idx)
+                chunks[idx] = "<<removed>>"
 
-        # remove all the small chunks
-        for num, idx in enumerate(indices_to_pop):
-            # as we keep popping items, we need to lower the idx we pop from
-            chunks.pop(idx - num)
+        chunks = list(filter(lambda val: val != "<<removed>>", chunks))
 
         return chunks
 
@@ -177,7 +173,7 @@ class VectorStoreInterface:
 
             for line in html2text_output.split("\n"):
                 # remove non printable chars (like paragraph markers)
-                line = "".join(filter(lambda x: x in string.printable, line))
+                line = "".join(filter(lambda char: char in string.printable, line))
 
                 # replace html2text code block start/end with standard md
                 if "[code]" in line:

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -228,9 +228,7 @@ class VectorStoreInterface:
 
         chunked_docs = self.split_to_docs(text, metadata)
 
-        from pprint import pprint
-
-        pprint(chunked_docs)
+        log.debug("document chunks: %s", chunked_docs)
 
         return chunked_docs
 

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -239,7 +239,7 @@ class VectorStoreInterface:
     def search(self, query, agent_id):
         if cfg.EMBED_QUERY_PREFIX:
             query = f"{cfg.EMBED_QUERY_PREFIX}: {query}"
-        results = self.store.max_marginal_relevance_search(
+        results = self.store.max_marginal_relevance_search_with_score(
             query=query, filter={"agent_id": str(agent_id)}, k=4
         )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - EMBED_BASE_URL=http://tangerine-text-embeddings-inference:8001/v1
       - LLM_MODEL_NAME=mistral
       - EMBED_MODEL_NAME=snowflake-arctic-embed-m-long
+      - EMBED_QUERY_PREFIX="Represent this sentence for searching relevant passages"
     healthcheck:
       test: curl --fail "http://localhost:5000/ping" || exit 1
       start_period: 10s

--- a/file_upload_cli.py
+++ b/file_upload_cli.py
@@ -28,8 +28,11 @@ def upload_files(source, directory_path, url, agent_id, html, bearer_token):
         start = i * batch_size
         end = (i + 1) * batch_size
         batch_files = files[start:end]
+        # skip 404.html files
         files_to_upload = [
-            ("file", (file_path, open(file_path, "rb"), "text/plain")) for file_path in batch_files
+            ("file", (file_path, open(file_path, "rb"), "text/plain"))
+            for file_path in batch_files
+            if not file_path.endswith("404.html")
         ]
 
         response = requests.post(

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -314,6 +314,8 @@ objects:
                 value: ${LLM_MODEL_NAME}
               - name: EMBED_MODEL_NAME
                 value: ${EMBED_MODEL_NAME}
+              - name: EMBED_QUERY_PREFIX
+                value: ${EMBED_QUERY_PREFIX}
             securityContext:
               capabilities: {}
               privileged: false
@@ -359,5 +361,7 @@ parameters:
     value: mistralai/Mistral-7B-Instruct-v0.2
   - name: EMBED_MODEL_NAME
     value: Snowflake/snowflake-arctic-embed-m-long
+  - name: EMBED_QUERY_PREFIX
+    value: "Represent this sentence for searching relevant passages"
   - name: LLM_TEMPERATURE
     value: "0.3"


### PR DESCRIPTION
* Use RecursiveCharacterTextSplitter with our own md separators because langchain's MarkdownTextSplitter and MarkdownHeaderTextSplitter do not give best results
* Detect small chunks, remove them, and add them to the next chunk to ensure all chunks have good context
* Use instructions with the embedding models when embedding document or asking question/querying
* LLM prompt tuning
* Store doc title on metadata and provide it to LLM
* Sort results by score
* Tell LLM if no search results were found