### PR TITLE
Document deletion enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ To run the UI in a development environment, see [tangerine-frontend](https://git
 | `/api/agents/<id>`                 | `GET`    | Get an agent               |
 | `/api/agents/<id>`                 | `PUT`    | Update an agent            |
 | `/api/agents/<id>`                 | `DELETE` | Delete an agent            |
-| `/api/agents/<id>/document_upload` | `POST`   | Agent document uploads     |
 | `/api/agents/<id>/chat`            | `POST`   | Chat with an agent         |
+| `/api/agents/<id>/documents`       | `POST`   | Agent document uploads     |
+| `/api/agents/<id>/documents`       | `DELETE` | Delete agent documents     |
 | `/api/agentDefaults`               | `GET`    | Get agent default settings |
 | `/ping`                            | `GET`    | Health check               |

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -277,13 +277,13 @@ class VectorStoreInterface:
         if not metadata:
             raise ValueError("empty metadata")
 
-        where_stmt = "WHERE cmetadata ->>'{key}'='{value}'"
-        where_stmts = []
+        filter_stmt = "cmetadata->>'{key}'='{value}'"
+        filter_stmts = []
         for key, value in metadata.items():
-            where_stmts.append(where_stmt.format(key=key, value=value))
-        filter_ = " AND ".join(where_stmts)
+            filter_stmts.append(filter_stmt.format(key=key, value=value))
+        filter_ = " AND ".join(filter_stmts)
 
-        query = text(f"SELECT id, cmetadata FROM langchain_pg_embedding {filter_};")
+        query = text(f"SELECT id, cmetadata FROM langchain_pg_embedding WHERE {filter_};")
         results = db.session.execute(query).all()
         metadatas = []
         for result in results:

--- a/connectors/vector_store/db.py
+++ b/connectors/vector_store/db.py
@@ -35,7 +35,7 @@ TXT_SEPARATORS = [
 
 
 class Agents(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     agent_name = db.Column(db.String(50), nullable=False)
     description = db.Column(db.Text, nullable=False)
     system_prompt = db.Column(db.Text, nullable=True)

--- a/file_upload_cli.py
+++ b/file_upload_cli.py
@@ -22,7 +22,7 @@ def upload_files(source, directory_path, url, agent_id, html, bearer_token):
         print("Using bearer auth")
         headers = {"Authorization": f"Bearer {bearer_token}"}
 
-    url = f"{url}/{agent_id}/document_upload"
+    url = f"{url}/{agent_id}/documents"
 
     for i in range(num_batches):
         start = i * batch_size

--- a/resources/routes.py
+++ b/resources/routes.py
@@ -1,4 +1,4 @@
-from .agent import (AgentApi, AgentChatApi, AgentDefaultsApi, AgentDocUpload,
+from .agent import (AgentApi, AgentChatApi, AgentDefaultsApi, AgentDocuments,
                     AgentsApi)
 from .utils import PingApi
 
@@ -7,6 +7,6 @@ def initialize_routes(api):
     api.add_resource(AgentDefaultsApi, "/api/agentDefaults")
     api.add_resource(AgentsApi, "/api/agents")
     api.add_resource(AgentApi, "/api/agents/<id>")
-    api.add_resource(AgentDocUpload, "/api/agents/<id>/document_upload")
+    api.add_resource(AgentDocuments, "/api/agents/<id>/documents")
     api.add_resource(AgentChatApi, "/api/agents/<id>/chat", methods=["GET", "POST"])
     api.add_resource(PingApi, "/ping", methods=["GET"])


### PR DESCRIPTION
* Delete documents from vector DB based on metadata ... any combination of 'source' / 'full_path' is accepted. You can also delete all docs for a specific agent ID.
* Rename document_upload API to 'documents'
* Simplify/refactor the delete logic
* Delete docs from the vector DB that match 'agent_id=N" whenever agent N is deleted