### PR TITLE
Fix 'endswith' error

### DIFF
--- a/connectors/db/file.py
+++ b/connectors/db/file.py
@@ -327,10 +327,11 @@ class File:
         if self.full_path.endswith(".md"):
             return _process_md(self.content, url=self.citation_url)
 
-        if self.full_path.endswith(".txt", ".rst"):
-            return self.content
-
         if self.full_path.endswith(".adoc"):
             return _adoc_to_md(os.path.basename(self.full_path), self.content)
 
+        if self.full_path.endswith(".txt") or self.full_path.endswith(".rst"):
+            return self.content
+
+        log.error("cannot extract text for unsupported file type: %s", self.full_path)
         return ""


### PR DESCRIPTION
Syntax error, we had not been hitting this code path until now...

```
^^^^^^^^^^^^^^^^^^^
File "/opt/app-root/src/connectors/db/file.py", line 330, in extract_text
if self.full_path.endswith(".txt", ".rst"):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: slice indices must be integers or None or have an __index__ method
```