### PR TITLE
Combine ask functions (assisted by cursor/claude-4-sonnet)

### DIFF
--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -206,7 +206,7 @@ class AssistantChatApi(Resource):
 
     def _call_llm(self, assistant, previous_messages, question, search_results, interaction_id):
         return llm.ask(
-            assistant,
+            [assistant],
             previous_messages,
             question,
             search_results,
@@ -369,7 +369,7 @@ class AssistantAdvancedChatApi(AssistantChatApi):
         if chunks:
             chunks = self._convert_chunk_array_to_documents(request.json.get("chunks"))
         search_results = chunks or search_engine.search(assistant_ids, question, embedding)
-        llm_response, search_metadata = llm.ask_advanced(
+        llm_response, search_metadata = llm.ask(
             assistants,
             previous_messages,
             question,


### PR DESCRIPTION
`ask` and `ask_advanced` had a lot of overlap, I noticed we could combine the two and alter all the places where `ask` was originally being called to pass in a list of 1 assistant (i.e. `[assistant]`) instead of a single one.

Assisted-by: Cursor IDE using claude-4-sonnet