### PR TITLE
Webdate web rca env var names in template

### DIFF
--- a/openshift/backend.template.yaml
+++ b/openshift/backend.template.yaml
@@ -55,7 +55,7 @@ parameters:
     value: "false"
   - name: JIRA_AGENT_URL
     value: "http://jira-agent:8000"
-  - name: WEBRCA_AGENT_URL
+  - name: WEB_RCA_AGENT_URL
     value: "http://webrca-agent:8000"
   - name: WEB_RCA_AGENT_CLIENT_ID
     value: "webrca-agent-client"
@@ -255,8 +255,8 @@ objects:
                 value: ${ENABLE_WEB_RCA_AGENT}
               - name: JIRA_AGENT_URL
                 value: ${JIRA_AGENT_URL}
-              - name: WEBRCA_AGENT_URL
-                value: ${WEBRCA_AGENT_URL}
+              - name: WEB_RCA_AGENT_URL
+                value: ${WEB_RCA_AGENT_URL}
               - name: WEB_RCA_AGENT_CLIENT_ID
                 value: ${WEB_RCA_AGENT_CLIENT_ID}
               - name: WEB_RCA_AGENT_CLIENT_SECRET

--- a/openshift/backend.template.yaml
+++ b/openshift/backend.template.yaml
@@ -51,7 +51,7 @@ parameters:
     value: "flask db upgrade"
   - name: ENABLE_JIRA_AGENT
     value: "false"
-  - name: ENABLE_WEBRCA_AGENT
+  - name: ENABLE_WEB_RCA_AGENT
     value: "false"
   - name: JIRA_AGENT_URL
     value: "http://jira-agent:8000"
@@ -251,8 +251,8 @@ objects:
                     key: api_key
               - name: ENABLE_JIRA_AGENT
                 value: ${ENABLE_JIRA_AGENT}
-              - name: ENABLE_WEBRCA_AGENT
-                value: ${ENABLE_WEBRCA_AGENT}
+              - name: ENABLE_WEB_RCA_AGENT
+                value: ${ENABLE_WEB_RCA_AGENT}
               - name: JIRA_AGENT_URL
                 value: ${JIRA_AGENT_URL}
               - name: WEBRCA_AGENT_URL


### PR DESCRIPTION
Some of the web rca env var names were wrong in the template resulting in the feature not functioning on a cluster