### PR TITLE
Remove query string from webrca request

### DIFF
--- a/src/tangerine/agents/webrca_agent.py
+++ b/src/tangerine/agents/webrca_agent.py
@@ -22,7 +22,6 @@ class WebRCAAgent:
             response = requests.get(
                 query_url,
                 headers={"Authorization": f"Bearer {token}"},
-                params={"query": query},
                 timeout=120,
             )
             response.raise_for_status()


### PR DESCRIPTION
There's no need for this to be in the request