### PR TITLE
Don't require prevMsgs from clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,35 @@ Variables are processed using Python's string formatting, so:
 - Missing variables will cause template errors
 - Extra variables in templates are ignored
 
+## Conversation History
+
+Tangerine automatically maintains conversation history to provide context for multi-turn conversations. As of version 2.0, conversation history is **automatically reconstructed** from the database, eliminating the need for clients to manually track conversation state.
+
+### Automatic History Management
+
+Both chat APIs (`/api/assistants/<id>/chat` and `/api/assistants/chat`) now automatically:
+- Look up existing conversation history using the `sessionId`
+- Provide the last 10 question-answer pairs as context to the LLM
+- Store the complete conversation history in the database
+
+**No client changes required** - simply provide a `sessionId` and Tangerine handles the rest:
+
+```bash
+curl -X POST http://localhost:8080/api/assistants/123/chat \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What was my previous question about?",
+    "sessionId": "433e4567-8e9b-22d3-a456-626614174000"
+  }'
+```
+
+### Legacy Support
+
+The `prevMsgs` parameter is still supported for backward compatibility but is **deprecated**:
+- Existing clients continue to work without changes
+- New integrations should omit `prevMsgs` and rely on automatic history reconstruction
+- When provided, `prevMsgs` takes precedence over auto-reconstruction
+
 ## Multiple Model Support
 You can extend Tangerine to support multiple models for use with the advanced chat API. In the future we plan to offer this purely through config, but as of this writing it requires minor modification to the Tangerine code.
 

--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ Variables are processed using Python's string formatting, so:
 
 ## Conversation History
 
-Tangerine automatically maintains conversation history to provide context for multi-turn conversations. As of version 2.0, conversation history is **automatically reconstructed** from the database, eliminating the need for clients to manually track conversation state.
+Tangerine automatically maintains conversation history to provide context for multi-turn conversations. Conversation history is **automatically reconstructed** from the database, eliminating the need for clients to manually track conversation state.
 
 ### Automatic History Management
 

--- a/README.md
+++ b/README.md
@@ -701,15 +701,17 @@ curl -X POST http://localhost:8080/api/assistants/123/chat \
   }'
 ```
 
-### Legacy Support
+### Simplified Implementation
 
-The `prevMsgs` parameter is still supported for backward compatibility but is **deprecated**:
-- Existing clients continue to work without changes
-- New integrations should omit `prevMsgs` and rely on automatic history reconstruction
-- When provided (and non-empty), `prevMsgs` takes precedence over auto-reconstruction
-- Empty `prevMsgs` array (`[]`) is respected and will not fall back to database history
+The `prevMsgs` parameter is **ignored** if provided - conversation history is always auto-reconstructed from the database:
+- **One code path**: All clients use the same reliable database-based history reconstruction
+- **No client complexity**: Clients never need to track or send conversation history
+- **Consistent behavior**: Same experience whether `prevMsgs` is provided or not
+- **Anonymous sessions**: Works with or without user identification
 
 ### Security Considerations
+
+**Session Ownership**: When a `user` is provided, the system verifies session ownership to prevent unauthorized access to conversation history. Anonymous sessions (no `user` provided) can access any session by `sessionId`.
 
 **Important**: The current implementation uses the `user` field from the request body for session ownership verification. In production environments, this should be replaced with authenticated user identity from:
 - JWT tokens

--- a/README.md
+++ b/README.md
@@ -706,7 +706,18 @@ curl -X POST http://localhost:8080/api/assistants/123/chat \
 The `prevMsgs` parameter is still supported for backward compatibility but is **deprecated**:
 - Existing clients continue to work without changes
 - New integrations should omit `prevMsgs` and rely on automatic history reconstruction
-- When provided, `prevMsgs` takes precedence over auto-reconstruction
+- When provided (and non-empty), `prevMsgs` takes precedence over auto-reconstruction
+- Empty `prevMsgs` array (`[]`) is respected and will not fall back to database history
+
+### Security Considerations
+
+**Important**: The current implementation uses the `user` field from the request body for session ownership verification. In production environments, this should be replaced with authenticated user identity from:
+- JWT tokens
+- Session-based authentication
+- OAuth/OIDC claims
+- API key-based user identification
+
+Using request body `user` field allows potential session hijacking if not properly validated against authenticated identity.
 
 ## Multiple Model Support
 You can extend Tangerine to support multiple models for use with the advanced chat API. In the future we plan to offer this purely through config, but as of this writing it requires minor modification to the Tangerine code.

--- a/src/tangerine/config.py
+++ b/src/tangerine/config.py
@@ -114,28 +114,36 @@ if ENABLE_LLAMA4_SCOUT:
 def get_model_config(model_name: str | None) -> dict:
     # AUDIT LOG: get_model_config entry
     log.info("AUDIT: get_model_config() called with model_name=%s", model_name)
-    
+
     original_model_name = model_name
     model_name = model_name or DEFAULT_MODEL
-    
+
     # AUDIT LOG: Model name resolution
-    log.info("AUDIT: Model name resolved from %s to %s (DEFAULT_MODEL=%s)", 
-             original_model_name, model_name, DEFAULT_MODEL)
+    log.info(
+        "AUDIT: Model name resolved from %s to %s (DEFAULT_MODEL=%s)",
+        original_model_name,
+        model_name,
+        DEFAULT_MODEL,
+    )
 
     if model_name not in MODELS:
-        log.error("AUDIT: INVALID MODEL in get_model_config - model_name=%s not in MODELS=%s", 
-                  model_name, list(MODELS.keys()))
+        log.error(
+            "AUDIT: INVALID MODEL in get_model_config - model_name=%s not in MODELS=%s",
+            model_name,
+            list(MODELS.keys()),
+        )
         raise ValueError(f"invalid model name: {model_name}")
 
     model_config = MODELS[model_name]
-    
+
     # AUDIT LOG: Model config found
     log.info("AUDIT: Found model_config for %s: %s", model_name, model_config)
 
     required_keys = ("model", "openai_api_base", "openai_api_key", "temperature")
     if not all([key in model_config for key in required_keys]):
-        log.error("AUDIT: INVALID MODEL CONFIG - missing keys for %s, config=%s", 
-                  model_name, model_config)
+        log.error(
+            "AUDIT: INVALID MODEL CONFIG - missing keys for %s, config=%s", model_name, model_config
+        )
         raise ValueError(
             f"model config for '{model_name}' missing one or more of required keys: {required_keys}"
         )

--- a/src/tangerine/llm.py
+++ b/src/tangerine/llm.py
@@ -107,20 +107,20 @@ def get_response(
 ) -> Generator[str, None, None]:
     # AUDIT LOG: get_response entry
     log.info("AUDIT: get_response() called with model_name=%s", model_name)
-    
+
     model_config = cfg.get_model_config(model_name)
-    
+
     # AUDIT LOG: Model config retrieved
     log.info("AUDIT: Retrieved model_config for model_name=%s: %s", model_name, model_config)
 
     # AUDIT LOG: Creating ChatOpenAI instance
     log.info("AUDIT: Creating ChatOpenAI with config: %s", model_config)
-    
+
     chat = ChatOpenAI(
         **model_config,
         stream_usage=True,
     )
-    
+
     # AUDIT LOG: ChatOpenAI instance created
     log.info("AUDIT: ChatOpenAI instance created successfully")
 
@@ -128,13 +128,13 @@ def get_response(
 
     completion_start = 0.0
     processing_start = time.time()
-    
+
     # AUDIT LOG: About to execute LLM chain
     log.info("AUDIT: Executing LLM chain with final model configuration")
 
     # AUDIT LOG: About to make HTTP request to model endpoint
     log.info("AUDIT: Starting HTTP stream request to model endpoint")
-    
+
     with get_openai_callback() as cb:
         for chunk in chain.stream(prompt_params):
             if not completion_start:
@@ -148,7 +148,7 @@ def get_response(
             completion_end = time.time()
 
         # end with
-    
+
     log.info("AUDIT: HTTP stream request to model endpoint completed successfully")
     _record_metrics(cb, processing_start, completion_start, completion_end)
 
@@ -192,10 +192,12 @@ def ask(
     user_prompt: str | None = None,
 ) -> tuple[Generator[str, None, None], list[dict]]:
     log.info("AUDIT: llm 'ask' request")
-    
+
     # AUDIT LOG: Function entry
     log.info("AUDIT: llm.ask() called with model=%s, disable_agentic=%s", model, disable_agentic)
-    log.info("AUDIT: Assistant details: %s", [{"name": a.name, "model": a.model} for a in assistants])
+    log.info(
+        "AUDIT: Assistant details: %s", [{"name": a.name, "model": a.model} for a in assistants]
+    )
     search_context = ""
     search_metadata = []
 
@@ -254,13 +256,17 @@ def ask(
     # Determine model: use provided model, then first assistant's model
     # TODO: handle the case where assistants are configured with different models
     selected_model = model or assistants[0].model
-    
+
     # AUDIT LOG: Model selection decision
-    log.info("AUDIT: Model selection - API model=%s, assistant[0].model=%s, selected_model=%s", 
-             model, assistants[0].model, selected_model)
+    log.info(
+        "AUDIT: Model selection - API model=%s, assistant[0].model=%s, selected_model=%s",
+        model,
+        assistants[0].model,
+        selected_model,
+    )
 
     prompt_params = {"context": search_context, "question": question}
-    
+
     # AUDIT LOG: About to call get_response
     log.info("AUDIT: Calling get_response() with selected_model=%s", selected_model)
     llm_response = get_response(ChatPromptTemplate(msg_list), prompt_params, selected_model)

--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -683,6 +683,7 @@ class AssistantAdvancedChatApi(AssistantChatApi):
 
         # NOTE: prevMsgs parameter is ignored - conversation history is auto-reconstructed from database
         # This simplifies client implementation and ensures consistent behavior
+        # TODO: remove this after confirming no clients are still using 'prevMsgs'
         _ = request.json.get("prevMsgs")  # Explicitly ignore if provided
 
         interaction_id = request.json.get("interactionId", None)

--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -267,7 +267,7 @@ class AssistantChatApi(Resource):
         Validate prevMsgs structure and sanitize if needed.
 
         Args:
-            prev_msgs: Client-provided prevMsgs to validate
+            prev_msgs: List of previous conversation messages to validate
 
         Returns:
             List of valid message objects, or empty list if invalid

--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -392,6 +392,7 @@ class AssistantChatApi(Resource):
         conversation_messages = [msg for msg in messages if msg.get("sender") in {"human", "ai"}]
 
         if not conversation_messages:
+            log.debug("AUDIT: No human/ai messages found after filtering, returning empty history")
             return []
 
         # Extract complete Q&A pairs (human → ai)
@@ -418,12 +419,14 @@ class AssistantChatApi(Resource):
 
             i += 1
 
-        # Take the last 10 pairs maximum
-        if len(pairs) > 10:
-            pairs = pairs[-10:]
+        # Take the last 10 pairs maximum (slice works even with fewer pairs)
+        original_pair_count = len(pairs)
+        pairs = pairs[-10:]
+
+        if original_pair_count > 10:
             log.info(
                 "AUDIT: Limited conversation history from %d to %d Q&A pairs for LLM context",
-                len(conversation_messages) // 2,
+                original_pair_count,
                 len(pairs),
             )
 

--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -357,6 +357,7 @@ class AssistantChatApi(Resource):
             validated_stored = self._validate_prev_msgs(stored_prev_msgs)
 
             # Apply rolling window to limit LLM context
+            # TODO: look up context size for selected model, count tokens to determine max history
             return self._limit_conversation_to_pairs(validated_stored)
 
         except Exception as e:

--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -228,6 +228,7 @@ class AssistantChatApi(Resource):
 
         # NOTE: prevMsgs parameter is ignored - conversation history is auto-reconstructed from database
         # This simplifies client implementation and ensures consistent behavior
+        # TODO: remove this after confirming no clients are still using 'prevMsgs'
         _ = request.json.get("prevMsgs")  # Explicitly ignore if provided
 
         interaction_id = request.json.get("interactionId", None)

--- a/src/tangerine/search.py
+++ b/src/tangerine/search.py
@@ -361,7 +361,9 @@ class SearchEngine:
                 deduped_results = self.deduplicate_results(results)
                 log.info("AUDIT: Calling _rerank_results() for %d results", len(deduped_results))
                 sorted_results = self._rerank_results(query, deduped_results)
-                log.info("AUDIT: LLM reranking succeeded, got %d sorted results", len(sorted_results))
+                log.info(
+                    "AUDIT: LLM reranking succeeded, got %d sorted results", len(sorted_results)
+                )
             except Exception:
                 log.error("AUDIT: LLM reranking FAILED - falling back to RRF sorting")
                 log.exception("model re-ranking failed")


### PR DESCRIPTION
This PR removes the requirements for the prevMsgs param in the chat APIs. The way things work right now the clients have to construct and maintain a log of the conversation. This is a bit onerous because it means every client has to basically re-implement the same logic. Since the introduction of chat history and interactions we don't actually need clients to do this anymore. Instead we can construct that history from the database. That's what this PR does.

The API still accepts prvMsgs as a param, we just ignore it. None of the return values of the API endpoints have changed. This means it should be a silent change as far as clients are concerned. However, over time, clients could stop worrying about constructing their internal conversation structure in exactly the way tangerine expects.