### PR TITLE
Use multi-stage build

### DIFF
--- a/.tekton/tangerine-backend-pull-request.yaml
+++ b/.tekton/tangerine-backend-pull-request.yaml
@@ -27,6 +27,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+  - name: build-args-file
+    value: ci-build-args.txt
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/tangerine-backend-push.yaml
+++ b/.tekton/tangerine-backend-push.yaml
@@ -24,6 +24,8 @@ spec:
     value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/tangerine/tangerine-backend:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: build-args-file
+    value: ci-build-args.txt
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use ARG to allow switching between development and production base images
 # Default: quay.io/sclorg/postgresql-16-c10s:latest (for local development)
-# Production: registry.redhat.io/rhel9/postgresql-16 (see ci-build-args.txt)
+# Production: registry.redhat.io/rhel10/postgresql-16:latest (see ci-build-args.txt)
 ARG BASE_IMAGE=quay.io/sclorg/postgresql-16-c10s:latest
 FROM ${BASE_IMAGE} AS builder
 
@@ -45,7 +45,6 @@ USER root
 RUN microdnf -y upgrade && \
     microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
         python3 \
-        python3-pip \
         libpq && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,57 @@
-#----------------------- base -----------------------
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+# Use ARG to allow switching between development and production base images
+# Default: quay.io/sclorg/postgresql-16-c10s:latest (for local development)
+# Production: registry.redhat.io/rhel9/postgresql-16 (see ci-build-args.txt)
+ARG BASE_IMAGE=quay.io/sclorg/postgresql-16-c10s:latest
+FROM ${BASE_IMAGE} AS builder
 
-ENV LC_ALL=C.utf8
-ENV LANG=C.utf8
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONIOENCODING=UTF-8
+# builder runs 'pipenv install' using postgres image to properly compile psycopg2
+
 ENV PIP_NO_CACHE_DIR=1
+ENV APP_ROOT=/opt/app-root/src
 
 USER root
 
-ENV APP_ROOT=/opt/app-root/src
 WORKDIR $APP_ROOT
 
-# install postgresql from centos if not building on RHEL host
-RUN ON_RHEL=$(microdnf repolist --enabled | grep rhel-9) ; \
-    if [ -z "$ON_RHEL" ] ; then \
-        rpm -Uvh http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-9.0-35.el9.noarch.rpm \
-                 http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-9.0-35.el9.noarch.rpm && \
-        sed -i 's/^\(enabled.*\)/\1\npriority=200/;' /etc/yum.repos.d/centos*.repo ; \
-    fi
-
-RUN microdnf -y module enable postgresql:16 && \
-    microdnf -y upgrade && \
-    microdnf -y install --setopt=install_weak_deps=0 --setopt=tsflags=nodocs python312 python3.12-pip which postgresql libpq && \
-    rpm -qa | sort > packages-before-devel-install.txt && \
-    microdnf -y install --setopt=install_weak_deps=0 --setopt=tsflags=nodocs python3.12-devel gcc make libpq-devel && \
-    rpm -qa | sort > packages-after-devel-install.txt
+RUN dnf -y upgrade && \
+    dnf -y install --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
+        gcc \
+        make \
+        python3-devel \
+        python3-pip \
+        which \
+        libpq-devel && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*
 
 COPY Pipfile .
 COPY Pipfile.lock .
 
-RUN python3.12 -m venv .venv && \
+RUN python3 -m venv .venv && \
     source .venv/bin/activate && \
-    python3.12 -m pip install --upgrade pip setuptools wheel pipenv && \
+    python3 -m pip install --upgrade pip setuptools wheel pipenv && \
     pipenv install --system --deploy --verbose
 
 ENV PATH="$APP_ROOT/.venv/bin:$PATH"
 
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
+
+ENV APP_ROOT=/opt/app-root/src
+ENV LC_ALL=C.utf8
+ENV LANG=C.utf8
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONIOENCODING=UTF-8
+ENV PATH="$APP_ROOT/.venv/bin:$PATH"
+
+USER root
+
+RUN microdnf -y upgrade && \
+    microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs python3 libpq && \
+    microdnf clean all && \
+    rm -rf /var/cache/dnf/*
+
+WORKDIR $APP_ROOT
+COPY --from=builder $APP_ROOT/.venv .venv
 COPY pyproject.toml .
 COPY src ./src
 COPY migrations ./migrations
@@ -45,12 +60,6 @@ RUN pip install .
 
 RUN mkdir /nltk_data && chown -R 1001:0 /nltk_data && chmod -R g=u /nltk_data
 ENV NLTK_DATA_DIR=/nltk_data
-
-# remove devel packages that may have only been necessary for psycopg to compile
-RUN microdnf remove -y $( comm -13 packages-before-devel-install.txt packages-after-devel-install.txt ) && \
-    rm packages-before-devel-install.txt packages-after-devel-install.txt && \
-    microdnf clean all && \
-    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 
 USER 1001
 

--- a/ci-build-args.txt
+++ b/ci-build-args.txt
@@ -1,1 +1,1 @@
-BASE_IMAGE=registry.redhat.io/rhel9/postgresql-16:9.7-1770309211
+BASE_IMAGE=registry.redhat.io/rhel10/postgresql-16:latest

--- a/ci-build-args.txt
+++ b/ci-build-args.txt
@@ -1,0 +1,1 @@
+BASE_IMAGE=registry.redhat.io/rhel9/postgresql-16:9.7-1770309211


### PR DESCRIPTION
* Use the postgres image to install/build the dependencies (mainly we need to do this so that psycopg2 compiles properly)

* Use ubi-minimal as a final image and copy the python virtual environment into the final image