### PR TITLE
Add pinGitHubActionDigestsToSemver to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     ":disableMajorUpdates",
     "github>konflux-ci/mintmaker-presets:cve-automerge-all",
-    "github>konflux-ci/mintmaker-presets:group-python-requirements"
+    "github>konflux-ci/mintmaker-presets:group-python-requirements",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "dockerfile": {
     "managerFilePatterns": [


### PR DESCRIPTION
Add missing config to renovate to being able to handle correctly the PRs for GitHub actions