### PR TITLE
Fixes response sources intermittently not appearing

### DIFF
--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -488,12 +488,16 @@ class AssistantChatApi(Resource):
         def __api_response_generator():
             accumulated_text = ""
 
-            for text in llm_response:
-                accumulated_text += text
-                chunk = {"text_content": text}
-                yield f"data: {json.dumps(chunk)}\r\n"
+            try:
+                for text in llm_response:
+                    accumulated_text += text
+                    chunk = {"text_content": text}
+                    yield f"data: {json.dumps(chunk)}\r\n"
+            except Exception:
+                log.exception("error during LLM streaming")
 
             # final piece of content returned is the search metadata
+            # always reached because the except above swallows any streaming error
             yield f"data: {json.dumps({'search_metadata': search_metadata})}\r\n"
 
             # log user interaction at the end

--- a/src/tangerine/resources/assistant.py
+++ b/src/tangerine/resources/assistant.py
@@ -497,7 +497,6 @@ class AssistantChatApi(Resource):
                 log.exception("error during LLM streaming")
 
             # final piece of content returned is the search metadata
-            # always reached because the except above swallows any streaming error
             yield f"data: {json.dumps({'search_metadata': search_metadata})}\r\n"
 
             # log user interaction at the end


### PR DESCRIPTION
## Change Details
- Fixes the issue with sources not appearing after an LLM generated response due to some error that would occur and cause the `search_metadata` SSE event to never reach the client
  - Wraps the LLM chunk collection logic in a try/catch block, the event metadata is returned always