### PR TITLE
Adds header context to chunked data, hardens handling of parsing Unicode characters

### DIFF
--- a/src/tangerine/file.py
+++ b/src/tangerine/file.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import re
-import string
 from io import StringIO
 from typing import Optional
 
@@ -374,8 +373,8 @@ def _html_to_md(content: str) -> str:
     in_code_block = False
 
     for line in html2text_output.split("\n"):
-        # remove non printable chars (like paragraph markers)
-        line = "".join(filter(lambda char: char in string.printable, line))
+        # remove non-printable chars (like paragraph markers), preserving valid unicode
+        line = "".join(char for char in line if char.isprintable() or char == "\t")
 
         # remove trailing "#" from header lines
         if re.match(r"#+ \S+", line):

--- a/src/tangerine/vector.py
+++ b/src/tangerine/vector.py
@@ -108,9 +108,18 @@ class VectorStoreInterface:
 
             markdown_documents = md_splitter.split_text(text)
             chunks = text_splitter.split_documents(markdown_documents)
-            # convert back to list[str] so we can filter and combine them
-            # TODO: figure out how to combine but also retain md header metadata?
-            chunks = [chunk.page_content for chunk in chunks]
+            # Prepend header breadcrumb to chunks that don't already open with a header,
+            # so mid-section chunks retain their section context after splitting.
+            header_keys = ("H1", "H2", "H3", "H4", "H5", "H6")
+            result = []
+            for chunk in chunks:
+                headers = [chunk.metadata[k] for k in header_keys if chunk.metadata.get(k)]
+                if headers and not chunk.page_content.lstrip().startswith("#"):
+                    breadcrumb = " > ".join(headers)
+                    result.append(f"{breadcrumb}\n\n{chunk.page_content}")
+                else:
+                    result.append(chunk.page_content)
+            chunks = result
         else:
             chunks = text_splitter.split_text(text)
 


### PR DESCRIPTION
## Change Details
- Industry standard practice for RAG workflows is at the start of each data chunk, we append the last-parsed header to retain maximal context during data retrieval - Tangerine now implements this, the results are noticeable from local testing
- Hardens Unicode character handling
  - Checks `character.isprintable` or if the character is a tab-character