### PR TITLE
glasswing: fix f002 — derive conversation identity from gateway header

### DIFF
--- a/src/tangerine/config.py
+++ b/src/tangerine/config.py
@@ -75,6 +75,11 @@ WEB_RCA_AGENT_CLIENT_ID = os.getenv("WEB_RCA_AGENT_CLIENT_ID", "EMPTY")
 WEB_RCA_AGENT_CLIENT_SECRET = os.getenv("WEB_RCA_AGENT_CLIENT_SECRET", "EMPTY")
 SSO_URL = os.getenv("SSO_URL", "https://sso.foo.com")
 
+# Header injected by the fronting auth proxy that carries the authenticated principal.
+# Identity for object-level authorization is derived from this header, never from the
+# request body (see README "Security Considerations").
+USER_IDENTITY_HEADER = os.getenv("USER_IDENTITY_HEADER", "X-Forwarded-User")
+
 # for nomic: 'search_query'
 # for snowflake-arctic-embed-m-long: 'Represent this sentence for searching relevant passages'
 EMBED_QUERY_PREFIX = os.getenv("EMBED_QUERY_PREFIX", "search_query")

--- a/src/tangerine/resources/conversation.py
+++ b/src/tangerine/resources/conversation.py
@@ -1,7 +1,29 @@
 from flask import request
 from flask_restful import Resource
 
+import tangerine.config as cfg
 from tangerine.models.conversation import Conversation
+
+
+def _get_authenticated_user():
+    """
+    Return the acting principal as asserted by the fronting auth proxy via the
+    USER_IDENTITY_HEADER (default: X-Forwarded-User), or None if absent.
+
+    Identity is intentionally NOT taken from the JSON request body: body fields are
+    fully attacker-controlled and using them for object-level authorization allows any
+    caller to read/modify/delete another user's conversations (CWE-639).
+    """
+    user = request.headers.get(cfg.USER_IDENTITY_HEADER)
+    if user:
+        user = user.strip()
+    return user or None
+
+
+_UNAUTHENTICATED = (
+    {"error": "Unauthenticated: missing identity header"},
+    401,
+)
 
 
 class ConversationListApi(Resource):
@@ -17,13 +39,9 @@ class ConversationListApi(Resource):
         """
         Handle POST requests to retrieve a list of conversations.
         """
-        data = request.get_json()
-        if not data:
-            return {"error": "No data provided"}, 400
-
-        user_id = data.get("user_id")
+        user_id = _get_authenticated_user()
         if not user_id:
-            return {"error": "User ID is required"}, 400
+            return _UNAUTHENTICATED
 
         try:
             conversation_objects = Conversation.get_by_user(user_id)
@@ -46,6 +64,10 @@ class ConversationRetrievalApi(Resource):
         """
         Handle POST requests to retrieve a specific conversation by ID.
         """
+        user_id = _get_authenticated_user()
+        if not user_id:
+            return _UNAUTHENTICATED
+
         data = request.get_json()
         if not data:
             return {"error": "No data provided"}, 400
@@ -58,6 +80,8 @@ class ConversationRetrievalApi(Resource):
             conversation = Conversation.get_by_session(session_id)
             if not conversation:
                 return {"error": "Conversation not found"}, 404
+            if not conversation.is_owned_by(user_id):
+                return {"error": "Unauthorized: You can only access your own conversations"}, 403
             return conversation.to_json(), 200
         except Exception as e:
             return {"error": str(e)}, 500
@@ -72,9 +96,19 @@ class ConversationUpsertApi(Resource):
         """
         Handle POST requests to upsert a conversation.
         """
+        user_id = _get_authenticated_user()
+        if not user_id:
+            return _UNAUTHENTICATED
+
         data = request.get_json()
         if not data:
             return {"error": "No data provided"}, 400
+
+        # Bind the upsert to the authenticated principal regardless of what the
+        # client placed in the body, so Conversation.upsert's ownership check keys
+        # off a trusted identity rather than attacker-controlled input.
+        data = dict(data)
+        data["user"] = user_id
 
         try:
             conversation = Conversation.upsert(data)
@@ -92,17 +126,18 @@ class ConversationDeleteApi(Resource):
         """
         Handle POST requests to delete a conversation.
         """
+        user_id = _get_authenticated_user()
+        if not user_id:
+            return _UNAUTHENTICATED
+
         data = request.get_json()
         if not data:
             return {"error": "No data provided"}, 400
 
         session_id = data.get("sessionId")
-        user_id = data.get("user_id")
 
         if not session_id:
             return {"error": "Session ID is required"}, 400
-        if not user_id:
-            return {"error": "User ID is required"}, 400
 
         try:
             success, message = Conversation.delete_by_session(session_id, user_id)

--- a/tests/test_conversation_authz.py
+++ b/tests/test_conversation_authz.py
@@ -31,8 +31,9 @@ def test_list_ignores_body_user_id_and_uses_header():
         headers={cfg.USER_IDENTITY_HEADER: "alice"},
         json_body={"user_id": "victim-bob"},
     )
-    with patch.object(conv, "request", req), patch.object(
-        conv.Conversation, "get_by_user", staticmethod(fake_get_by_user)
+    with (
+        patch.object(conv, "request", req),
+        patch.object(conv.Conversation, "get_by_user", staticmethod(fake_get_by_user)),
     ):
         body, status = conv.ConversationListApi().post()
     assert status == 200
@@ -56,8 +57,9 @@ def test_retrieval_enforces_ownership():
         headers={cfg.USER_IDENTITY_HEADER: "alice"},
         json_body={"sessionId": "11111111-1111-1111-1111-111111111111"},
     )
-    with patch.object(conv, "request", req), patch.object(
-        conv.Conversation, "get_by_session", staticmethod(lambda sid: other)
+    with (
+        patch.object(conv, "request", req),
+        patch.object(conv.Conversation, "get_by_session", staticmethod(lambda sid: other)),
     ):
         body, status = conv.ConversationRetrievalApi().post()
     assert status == 403
@@ -74,8 +76,9 @@ def test_upsert_overrides_body_user_with_header_principal():
         headers={cfg.USER_IDENTITY_HEADER: "alice"},
         json_body={"user": "anonymous", "sessionId": "s", "prevMsgs": []},
     )
-    with patch.object(conv, "request", req), patch.object(
-        conv.Conversation, "upsert", staticmethod(fake_upsert)
+    with (
+        patch.object(conv, "request", req),
+        patch.object(conv.Conversation, "upsert", staticmethod(fake_upsert)),
     ):
         body, status = conv.ConversationUpsertApi().post()
     assert status == 200
@@ -93,8 +96,9 @@ def test_delete_uses_header_principal_not_body():
         headers={cfg.USER_IDENTITY_HEADER: "alice"},
         json_body={"sessionId": "s", "user_id": "victim-bob"},
     )
-    with patch.object(conv, "request", req), patch.object(
-        conv.Conversation, "delete_by_session", staticmethod(fake_delete)
+    with (
+        patch.object(conv, "request", req),
+        patch.object(conv.Conversation, "delete_by_session", staticmethod(fake_delete)),
     ):
         body, status = conv.ConversationDeleteApi().post()
     assert status == 200

--- a/tests/test_conversation_authz.py
+++ b/tests/test_conversation_authz.py
@@ -1,0 +1,101 @@
+"""Regression tests for object-level authorization on /api/conversations/* endpoints.
+
+Identity must be derived from the gateway-injected USER_IDENTITY_HEADER, never from
+the JSON request body. These tests stub Flask's request and the model layer so they
+exercise the authz logic in isolation.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import tangerine.config as cfg
+from tangerine.resources import conversation as conv
+
+
+def _fake_request(headers=None, json_body=None):
+    return SimpleNamespace(
+        headers=headers or {},
+        get_json=lambda: json_body,
+    )
+
+
+def test_list_ignores_body_user_id_and_uses_header():
+    """ConversationListApi must scope to the header principal, not body user_id."""
+    seen = {}
+
+    def fake_get_by_user(uid):
+        seen["uid"] = uid
+        return []
+
+    req = _fake_request(
+        headers={cfg.USER_IDENTITY_HEADER: "alice"},
+        json_body={"user_id": "victim-bob"},
+    )
+    with patch.object(conv, "request", req), patch.object(
+        conv.Conversation, "get_by_user", staticmethod(fake_get_by_user)
+    ):
+        body, status = conv.ConversationListApi().post()
+    assert status == 200
+    assert seen["uid"] == "alice"  # NOT "victim-bob"
+
+
+def test_list_rejects_missing_identity_header():
+    req = _fake_request(headers={}, json_body={"user_id": "victim-bob"})
+    with patch.object(conv, "request", req):
+        body, status = conv.ConversationListApi().post()
+    assert status == 401
+
+
+def test_retrieval_enforces_ownership():
+    """ConversationRetrievalApi must 403 when the session belongs to another user."""
+    other = SimpleNamespace(
+        is_owned_by=lambda uid: uid == "bob",
+        to_json=lambda: {"session_id": "s"},
+    )
+    req = _fake_request(
+        headers={cfg.USER_IDENTITY_HEADER: "alice"},
+        json_body={"sessionId": "11111111-1111-1111-1111-111111111111"},
+    )
+    with patch.object(conv, "request", req), patch.object(
+        conv.Conversation, "get_by_session", staticmethod(lambda sid: other)
+    ):
+        body, status = conv.ConversationRetrievalApi().post()
+    assert status == 403
+
+
+def test_upsert_overrides_body_user_with_header_principal():
+    captured = {}
+
+    def fake_upsert(data):
+        captured.update(data)
+        return SimpleNamespace(to_json=lambda: {})
+
+    req = _fake_request(
+        headers={cfg.USER_IDENTITY_HEADER: "alice"},
+        json_body={"user": "anonymous", "sessionId": "s", "prevMsgs": []},
+    )
+    with patch.object(conv, "request", req), patch.object(
+        conv.Conversation, "upsert", staticmethod(fake_upsert)
+    ):
+        body, status = conv.ConversationUpsertApi().post()
+    assert status == 200
+    assert captured["user"] == "alice"  # 'anonymous' bypass closed
+
+
+def test_delete_uses_header_principal_not_body():
+    seen = {}
+
+    def fake_delete(session_id, user_id):
+        seen["uid"] = user_id
+        return True, "Conversation deleted successfully"
+
+    req = _fake_request(
+        headers={cfg.USER_IDENTITY_HEADER: "alice"},
+        json_body={"sessionId": "s", "user_id": "victim-bob"},
+    )
+    with patch.object(conv, "request", req), patch.object(
+        conv.Conversation, "delete_by_session", staticmethod(fake_delete)
+    ):
+        body, status = conv.ConversationDeleteApi().post()
+    assert status == 200
+    assert seen["uid"] == "alice"


### PR DESCRIPTION
All four /api/conversations/* handlers read the acting user from the JSON request body (user_id / user), which is fully attacker-controlled, and used it for object-level authorization. Any caller could list, read, overwrite or delete another user's conversations by supplying the victim's user_id, and Conversation.upsert's anonymous→None branch let user:'anonymous' overwrite any session (CWE-639 / CWE-284).

Add USER_IDENTITY_HEADER (default X-Forwarded-User) and a _get_authenticated_user() helper that reads it; require it on all four endpoints (401 if absent), pass the header-derived principal to get_by_user/delete_by_session, override body 'user' before Conversation.upsert, and add an is_owned_by check to ConversationRetrievalApi. Body-supplied user_id/user fields are now ignored for authorization.

Addresses: analysis-results/findings/backstage/tangerine-backend/tangerine-backend-triage.json#f002
CWEs: CWE-639, CWE-284