### PR TITLE
glasswing: fix f001 — redact LLM API key in model_config log lines

### DIFF
--- a/src/tangerine/config.py
+++ b/src/tangerine/config.py
@@ -111,6 +111,14 @@ if ENABLE_LLAMA4_SCOUT:
     }
 
 
+_REDACT_KEYS = ("openai_api_key",)
+
+
+def redact_model_config(model_config: dict) -> dict:
+    """Return a copy of model_config with secret fields masked for safe logging."""
+    return {k: ("***" if k in _REDACT_KEYS else v) for k, v in model_config.items()}
+
+
 def get_model_config(model_name: str | None) -> dict:
     # AUDIT LOG: get_model_config entry
     log.info("AUDIT: get_model_config() called with model_name=%s", model_name)
@@ -137,12 +145,14 @@ def get_model_config(model_name: str | None) -> dict:
     model_config = MODELS[model_name]
 
     # AUDIT LOG: Model config found
-    log.info("AUDIT: Found model_config for %s: %s", model_name, model_config)
+    log.info("AUDIT: Found model_config for %s: %s", model_name, redact_model_config(model_config))
 
     required_keys = ("model", "openai_api_base", "openai_api_key", "temperature")
     if not all([key in model_config for key in required_keys]):
         log.error(
-            "AUDIT: INVALID MODEL CONFIG - missing keys for %s, config=%s", model_name, model_config
+            "AUDIT: INVALID MODEL CONFIG - missing keys for %s, config=%s",
+            model_name,
+            redact_model_config(model_config),
         )
         raise ValueError(
             f"model config for '{model_name}' missing one or more of required keys: {required_keys}"

--- a/src/tangerine/llm.py
+++ b/src/tangerine/llm.py
@@ -109,12 +109,13 @@ def get_response(
     log.info("AUDIT: get_response() called with model_name=%s", model_name)
 
     model_config = cfg.get_model_config(model_name)
+    safe_config = cfg.redact_model_config(model_config)
 
     # AUDIT LOG: Model config retrieved
-    log.info("AUDIT: Retrieved model_config for model_name=%s: %s", model_name, model_config)
+    log.info("AUDIT: Retrieved model_config for model_name=%s: %s", model_name, safe_config)
 
     # AUDIT LOG: Creating ChatOpenAI instance
-    log.info("AUDIT: Creating ChatOpenAI with config: %s", model_config)
+    log.info("AUDIT: Creating ChatOpenAI with config: %s", safe_config)
 
     chat = ChatOpenAI(
         **model_config,

--- a/tests/test_config_redaction.py
+++ b/tests/test_config_redaction.py
@@ -1,0 +1,38 @@
+"""Regression tests for secret redaction in model-config logging."""
+
+import logging
+
+import tangerine.config as cfg
+
+
+def test_redact_model_config_masks_api_key():
+    raw = {
+        "model": "mistral",
+        "openai_api_base": "http://localhost:11434/v1",
+        "openai_api_key": "sk-super-secret",
+        "temperature": 0.7,
+    }
+    redacted = cfg.redact_model_config(raw)
+    assert redacted["openai_api_key"] == "***"
+    assert redacted["model"] == "mistral"
+    assert redacted["openai_api_base"] == "http://localhost:11434/v1"
+    # original must not be mutated
+    assert raw["openai_api_key"] == "sk-super-secret"
+
+
+def test_get_model_config_does_not_log_api_key(caplog):
+    secret = "sk-leak-canary-12345"
+    cfg.MODELS["_test_redact"] = {
+        "model": "m",
+        "openai_api_base": "http://localhost",
+        "openai_api_key": secret,
+        "temperature": 0.0,
+    }
+    try:
+        with caplog.at_level(logging.INFO, logger="tangerine.config"):
+            result = cfg.get_model_config("_test_redact")
+        assert result["openai_api_key"] == secret  # caller still gets the real key
+        for record in caplog.records:
+            assert secret not in record.getMessage()
+    finally:
+        cfg.MODELS.pop("_test_redact", None)


### PR DESCRIPTION
get_model_config() and llm.get_response() logged the full model_config dict (including openai_api_key, sourced from the LLM_API_KEY K8s Secret) at INFO on every chat request, disclosing the upstream LLM bearer token to any log-reader principal on the cluster logging stack. Add redact_model_config() to mask the openai_api_key field and use it at all four log sites. Callers still receive the real key; only log output changes.

Addresses: analysis-results/findings/backstage/tangerine-backend/tangerine-backend-triage.json#f001
CWEs: CWE-532, CWE-312